### PR TITLE
Bug fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,19 @@ npm install --save-dev @jgarber/eleventy-plugin-postcss
 ```
 
 ```js
+// eleventy.config.js
 module.exports = function(eleventyConfig) {
-  eleventyConfig.addPlugin(require('@jgarber/eleventy-plugin-postcss'), {
-    postcssConfig: {
-      map: 'inline',
-      plugins: [
-        require('postcss-nesting'),
-        require('cssnano')
-      ]
-    }
-  });
+  eleventyConfig.addPlugin(require('@jgarber/eleventy-plugin-postcss'));
+};
+```
+
+```js
+// postcss.config.js
+module.exports = {
+  map: 'inline',
+  plugins: [
+    require('postcss-nesting'),
+    require('cssnano')
+  ]
 };
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jgarber/eleventy-plugin-postcss",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jgarber/eleventy-plugin-postcss",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "postcss": "^8.4.33",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jgarber/eleventy-plugin-postcss",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "An Eleventy plugin for processing CSS files with PostCSS.",
   "keywords": [
     "eleventy",


### PR DESCRIPTION
- Remove support for passing a PostCSS config object in via plugin configuration. This was buggy and doesn't really play well with the underlying postcss-load-config (which is extremely file-centric).
- Simplify `templateFormats` configuration (turn