### PR TITLE
Convert project from ESM to CommonJS

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -1,12 +1,11 @@
-import fs from 'node:fs/promises';
-import path from 'node:path';
+const path = require('node:path');
 
-import postcss from 'postcss';
-import postcssrc from 'postcss-load-config';
+const postcss = require('postcss');
+const postcssrc = require('postcss-load-config');
 
-const package_ = JSON.parse(await fs.readFile('./package.json'));
+const package_ = require('./package.json');
 
-export default function(eleventyConfig, options = {}) {
+module.exports = function(eleventyConfig, options = {}) {
   try {
     eleventyConfig.versionCheck(package_['11ty'].compatibility);
   } catch (error) {
@@ -54,4 +53,4 @@ export default function(eleventyConfig, options = {}) {
       };
     }
   });
-}
+};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,7 +1,7 @@
-import ava from '@jgarber/eslint-config/ava';
-import config from '@jgarber/eslint-config';
+const ava = require('@jgarber/eslint-config/ava');
+const config = require('@jgarber/eslint-config');
 
-export default [
+module.exports = [
   ...config,
   ...ava
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jgarber/eleventy-plugin-postcss",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jgarber/eleventy-plugin-postcss",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "postcss": "^8.4.33",
@@ -279,14 +279,14 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.13",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
-      "integrity": "sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==",
+      "version": "0.11.14",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+      "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@humanwhocodes/object-schema": "^2.0.1",
-        "debug": "^4.1.1",
+        "@humanwhocodes/object-schema": "^2.0.2",
+        "debug": "^4.3.1",
         "minimatch": "^3.0.5"
       },
       "engines": {
@@ -308,9 +308,9 @@
       }
     },
     "node_modules/@humanwhocodes/object-schema": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
-      "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
+      "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
       "dev": true,
       "peer": true
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jgarber/eleventy-plugin-postcss",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "An Eleventy plugin for processing CSS files with PostCSS.",
   "keywords": [
     "eleventy",
@@ -14,7 +14,6 @@
   "files": [
     "eleventy.config.js"
   ],
-  "type": "module",
   "exports": {
     "./package.json": "./package.json",
     ".": "./eleventy.config.js"


### PR DESCRIPTION
It's easier for ESM projects to import using `package.json` configuration than vice-versa without a build step. There's no _need_ for this package to be ESM right now, so… CommonJS it is.
