### PR TITLE
Account for global default layouts

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,12 @@ module.exports = function(eleventyConfig, options = {}) {
       }
     },
 
+    getData: async () => {
+      return {
+        layout: false,
+      };
+    },
+
     compileOptions: {
       permalink: (inputContent, inputPath) => {
         if (path.parse(inputPath).name.startsWith("_")) {

--- a/test/fixtures/default-global-layout/_includes/layout.liquid
+++ b/test/fixtures/default-global-layout/_includes/layout.liquid
@@ -1,0 +1,6 @@
+<!doctype html>
+<html>
+<body>
+  {{ content }}
+</body>
+</html>

--- a/test/fixtures/default-global-layout/default-global-layout.11tydata.js
+++ b/test/fixtures/default-global-layout/default-global-layout.11tydata.js
@@ -1,0 +1,1 @@
+module.exports = { layout: "layout.liquid" };

--- a/test/fixtures/default-global-layout/eleventy.config.js
+++ b/test/fixtures/default-global-layout/eleventy.config.js
@@ -1,0 +1,3 @@
+module.exports = function(eleventyConfig) {
+  eleventyConfig.addPlugin(require("../../../"));
+};

--- a/test/fixtures/default-global-layout/styles.css
+++ b/test/fixtures/default-global-layout/styles.css
@@ -1,0 +1,3 @@
+html {
+  font-family: sans-serif;
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -34,6 +34,19 @@ test("custom templateFormats option", async () => {
   assert.strictEqual(console.log.mock.callCount(), 1);
 });
 
+test("default layout", async () => {
+  const eleventy = new Eleventy("test/fixtures/default-global-layout", null, {
+    configPath: "test/fixtures/default-global-layout/eleventy.config.js",
+  });
+
+  const results = await eleventy.toJSON();
+
+  const expected = `html {\n  font-family: sans-serif;\n}\n`;
+
+  assert.strictEqual(results[0].content, expected);
+  assert.strictEqual(console.log.mock.callCount(), 1);
+});
+
 test("Sass-style partials", async () => {
   const eleventy = new Eleventy("test/fixtures/partials", null, { configPath: "index.js" });
   const results = await eleventy.toJSON();


### PR DESCRIPTION
## Description

This PR fixes an issue where a layout file configured for use by all templates (for example, configured using an `.11tydata.js` file in the root of the source folder) would impose a layout (HTML, most likely) on the generated CSS files. That's not great, so this PR implements the suggestion made by @justinfagnani in #18. Tests have been added to confirm the change behaves as intended.

In other words, this plugin now disables layouts for CSS files.

Resolves #18.

## Commits

- Add failing specs (#18)
- Disable layouts in CSS files (#18)
